### PR TITLE
Update Dockerfile to run with OpenJDK 8 JRE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,20 @@
-FROM dockerfile/java:oracle-java8
+FROM java:8-jre
 
-RUN apt-get update
+ENV QUOBYTE_REPO_ID <QUOBYTE_REPO_ID>
 
-RUN apt-get install apt-transport-https
-RUN wget -q http://support.quobyte.com/repo/1/<QUOBYTE_REPO_ID>/xUbuntu_14.04/Release.key -O - | sudo apt-key add -
-RUN add-apt-repository "deb https://support.quobyte.com/repo/1/<QUOBYTE_REPO_ID>/xUbuntu_14.04 ./"
-RUN apt-get update
+RUN apt-get update && \
+    apt-get install -y \
+    apt-transport-https \
+    python-software-properties
 
-RUN apt-get install -y quobyte-server quobyte-client dnsutils
+RUN wget -q https://support.quobyte.com/repo/2/${QUOBYTE_REPO_ID}/xUbuntu_14.10/Release.key -O - | apt-key add - && \
+    echo "deb https://support.quobyte.com/repo/2/${QUOBYTE_REPO_ID}/xUbuntu_14.10 ./" > /etc/apt/sources.list.d/quobyte.list
+
+RUN apt-get update && \
+    apt-get install -y \
+    quobyte-server \
+    quobyte-client \
+    dnsutils
 
 ADD ./main.sh /opt/main.sh
 ENTRYPOINT ["/opt/main.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,5 +16,5 @@ RUN apt-get update && \
     quobyte-client \
     dnsutils
 
-ADD ./main.sh /opt/main.sh
+COPY ./main.sh /opt/main.sh
 ENTRYPOINT ["/opt/main.sh"]


### PR DESCRIPTION
This updates the `Dockerfile` to use OpenJDK 8 JRE for two reasons:
- `dockerfile` has been [deprecated](https://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/) and so one has to use [official java images](https://registry.hub.docker.com/u/library/java/)
- JRE images are smaller than JDK images

In the past Oracle Java was used but I did not experience errors when switching OpenJDK. This is mainly driven by the fact that the official Docker images don't ship Oracle Java because of licensing issues:

> As all of the major upstream Linux distributions are unwilling to redistribute Oracle Java in their own distribution channels, we have chosen to follow them.

@quofelix Do you see any problems with this? If this is a problem we should still be able to install Oracle Java by using the webupd8 PPA.
