### PR TITLE
Kubernetes add nodename and check fuse.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Scripts and tools for deploying Quobyte installations
 Currently contains:
  * **Ansible** script for AWS deployments
  * device initialization tools: **qbootstrap** and **qmkdev**
+ * **Kubernetes** specification files for Quobyte on Kubernetes
 
 For **Puppet**, please refer to SysEleven's recipes:
 https://github.com/syseleven/puppet-quobyte
@@ -13,3 +14,6 @@ https://github.com/bechtoldt/saltstack-quobyte-formula
 
 For **Mesos**, please check out our Mesos framework:
 https://github.com/quobyte/mesos-framework
+
+For automated **Kubernetes** deployments checkout Quobyte Deployer (community tool):
+https://github.com/johscheuer/quobyte-kubernetes-operator

--- a/kubernetes/client-ds.yaml
+++ b/kubernetes/client-ds.yaml
@@ -18,8 +18,14 @@ spec:
           - -xec
           - |
             ADDR=$(echo $(nslookup ${QUOBYTE_REGISTRY} | grep -A10 -m1 -e 'Name:' | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7866"}') | tr ' ' ,)
+            if [[ ! -f /rootfs/etc/fuse.conf ]]; then
+              echo "Copy fuse config to host"
+              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /rootfs/etc/fuse.conf
+            fi
+            if [[ $(grep "^[^#]" /rootfs/etc/fuse.conf  | grep -c "user_allow_other" /rootfs/etc/fuse.conf) -eq 0 ]]; then
+              echo "user_allow_other" >> /rootfs/etc/fuse.conf
+            fi
             if cut -d" " -f2 /etc/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
-              # test this case
               OPTS="-o remount"
             else
               mkdir -p ${QUOBYTE_MOUNT_POINT}
@@ -27,7 +33,7 @@ spec:
             /bin/nsenter -t 1 --wd=. -m -- \
               lib/ld-linux-x86-64.so.2 \
               --library-path ./lib \
-            ./bin/mount.quobyte --allow-usermapping-in-volumename -f -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
+            ./bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename -f -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
         securityContext:
           privileged: true
         env:
@@ -39,6 +45,10 @@ spec:
             value: registry
           - name: QUOBYTE_MOUNT_POINT
             value: /var/lib/kubelet/plugins/kubernetes.io~quobyte
+          - name: NODENAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         ports:
           - name: http-port
             containerPort: 55000

--- a/kubernetes/data-ds.yaml
+++ b/kubernetes/data-ds.yaml
@@ -20,14 +20,10 @@ spec:
             value: data
           - name: QUOBYTE_REGISTRY
             value: registry
-          - name: POD_NAME
+          - name: NODENAME
             valueFrom:
               fieldRef:
-                fieldPath: metadata.name
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+                fieldPath: spec.nodeName
           - name: MAX_MEM
             valueFrom:
               configMapKeyRef:
@@ -42,12 +38,13 @@ spec:
           - /bin/bash
           - -xec
           - |
+            hostname $NODENAME
             sed "s/.*MIN_MEM_DATA=.*/MIN_MEM_DATA=${MIN_MEM}/" -i /etc/default/quobyte
             sed "s/.*MAX_MEM_DATA=.*/MAX_MEM_DATA=${MAX_MEM}/" -i /etc/default/quobyte
             if [ ! -f /devices/data/QUOBYTE_DEV_SETUP ]; then
               mkdir -p /devices/data
               cat >/devices/data/QUOBYTE_DEV_SETUP <<EOF
-            device.serial=${POD_NAME}-$(uuidgen)
+            device.serial=$(uuidgen)
             device.model=Kubernetes-hostDir
             device.type=DATA_DEVICE
             EOF

--- a/kubernetes/metadata-ds.yaml
+++ b/kubernetes/metadata-ds.yaml
@@ -20,14 +20,10 @@ spec:
             value: metadata
           - name: QUOBYTE_REGISTRY
             value: registry
-          - name: POD_NAME
+          - name: NODENAME
             valueFrom:
               fieldRef:
-                fieldPath: metadata.name
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+                fieldPath: spec.nodeName
           - name: MAX_MEM
             valueFrom:
               configMapKeyRef:
@@ -42,12 +38,13 @@ spec:
           - /bin/bash
           - -xec
           - |
+            hostname $NODENAME
             sed "s/.*MIN_MEM_METADATA=.*/MIN_MEM_METADATA=${MIN_MEM}/" -i /etc/default/quobyte
             sed "s/.*MAX_MEM_METADATA=.*/MAX_MEM_METADATA=${MAX_MEM}/" -i /etc/default/quobyte
             if [ ! -f /devices/metadata/QUOBYTE_DEV_SETUP ]; then
               mkdir -p /devices/metadata
               cat >/devices/metadata/QUOBYTE_DEV_SETUP <<EOF
-            device.serial=${POD_NAME}-$(uuidgen)
+            device.serial=$(uuidgen)
             device.model=Kubernetes-hostDir
             device.type=METADATA_DEVICE
             EOF

--- a/kubernetes/registry-ds.yaml
+++ b/kubernetes/registry-ds.yaml
@@ -24,14 +24,10 @@ spec:
               value: "7876"
             - name: QUOBYTE_REGISTRY
               value: registry
-            - name: POD_NAME
+            - name: NODENAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.name
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
+                  fieldPath: spec.nodeName
             - name: QUOBYTE_EXTRA_SERVICE_CONFIG
               value: >
                 constants.automation.manage_registry_replicas=true
@@ -48,12 +44,15 @@ spec:
           ports:
             - name: rpc-tcp
               containerPort: 7866
+              hostPort: 7866
               protocol: TCP
             - name: rpc-udp
               containerPort: 7866
+              hostPort: 7866
               protocol: UDP
             - name: http
               containerPort: 7876
+              hostPort: 7876
               protocol: TCP
           volumeMounts:
             - name: devices
@@ -62,12 +61,13 @@ spec:
             - /bin/bash
             - -xec
             - |
+              hostname $NODENAME
               sed "s/.*MIN_MEM_REGISTRY=.*/MIN_MEM_REGISTRY=${MIN_MEM}/" -i /etc/default/quobyte
               sed "s/.*MAX_MEM_REGISTRY=.*/MAX_MEM_REGISTRY=${MAX_MEM}/" -i /etc/default/quobyte
               if [ ! -f /devices/dev1/QUOBYTE_DEV_SETUP ]; then
                 mkdir -p /devices/dev1
                 cat > /devices/dev1/QUOBYTE_DEV_SETUP <<EOF
-              device.serial=${POD_NAME}-$(uuidgen)
+              device.serial=$(uuidgen)
               device.model=Kubernetes-hostDir
               device.type=DIR_DEVICE
               EOF

--- a/kubernetes/webconsole-deployment.yaml
+++ b/kubernetes/webconsole-deployment.yaml
@@ -22,14 +22,6 @@ spec:
             value: registry:7866
           - name: QUOBYTE_API
             value: api:7860
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
           - name: MAX_MEM
             valueFrom:
               configMapKeyRef:
@@ -66,14 +58,6 @@ spec:
             value: registry:7866
           - name: QUOBYTE_LOG_LEVEL
             value: DEBUG
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
           - name: MAX_MEM
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
This PR adds the following features:

- Check if fuse.conf exists and contains `user_allow_other`
- Give Services the name of the Node name