### PR TITLE
Remove privileged mode

### DIFF
--- a/kubernetes/client-ds.yaml
+++ b/kubernetes/client-ds.yaml
@@ -6,27 +6,35 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: '/prometheus'
+        prometheus.io/port: '55000'
       labels:
         role: client
-        version: 1.3.12
+        version: 1.3.15
     spec:
       containers:
       - name: quobyte-client
-        image: quay.io/quobyte/quobyte-client:1.3.12
+        image: quay.io/quobyte/quobyte-client:1.3.15
         command:
           - /bin/sh
           - -xec
           - |
-            ADDR=$(echo $(nslookup ${QUOBYTE_REGISTRY} | grep -A10 -m1 -e 'Name:' | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7866"}') | tr ' ' ,)
-            if [[ ! -f /rootfs/etc/fuse.conf ]]; then
+            ADDR=$(echo $(nslookup ${QUOBYTE_REGISTRY} | grep -A10 -m1 -e 'Name:' | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7861"}') | tr ' ' ,)
+            if [[ ! -f /etcfs/fuse.conf ]]; then
               echo "Copy fuse config to host"
-              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /rootfs/etc/fuse.conf
+              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /etcfs/fuse.conf
             fi
-            if [[ $(grep "^[^#]" /rootfs/etc/fuse.conf  | grep -c "user_allow_other" /rootfs/etc/fuse.conf) -eq 0 ]]; then
-              echo "user_allow_other" >> /rootfs/etc/fuse.conf
+            if [[ $(grep "^[^#]" /etcfs/fuse.conf  | grep -c "user_allow_other" /etcfs/fuse.conf) -eq 0 ]]; then
+              echo "user_allow_other" >> /etcfs/fuse.conf
             fi
-            if cut -d" " -f2 /etc/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
-              OPTS="-o remount"
+            if cut -d" " -f2 /etcfs/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
+              if [[ -z $OPTS ]]; then
+                 OPTS="-o remount"
+              else
+                OPTS="$OPTS,remount"
+              fi
             else
               mkdir -p ${QUOBYTE_MOUNT_POINT}
             fi
@@ -37,8 +45,6 @@ spec:
         securityContext:
           privileged: true
         env:
-          - name: QUOBYTE_CLIENT_HTTP_PORT
-            value: "55000"
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
           - name: QUOBYTE_REGISTRY
@@ -54,20 +60,33 @@ spec:
             containerPort: 55000
             hostPort: 55000
             protocol: TCP
+        readinessProbe:
+          timeoutSeconds: 5
+          httpGet:
+            port: 55000
+            path: /
+        livenessProbe:
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          httpGet:
+            port: 55000
+            path: /
         volumeMounts:
           - name: k8s-plugin-dir
             mountPath: /var/lib/kubelet/plugins
-          - name: rootfs
-            mountPath: /rootfs
+          - name: etcfs
+            mountPath: /etcfs
         lifecycle:
           preStop:
             exec:
               command: ["/bin/bash", "-xc", "umount -f ${QUOBYTE_MOUNT_POINT}"]
       hostPID: true
+      nodeSelector:
+        quobyte_client: "true"
       volumes:
       - name: k8s-plugin-dir
         hostPath:
           path: /var/lib/kubelet/plugins
-      - name: rootfs
+      - name: etcfs
         hostPath:
-          path: /
+          path: /etc

--- a/kubernetes/data-ds.yaml
+++ b/kubernetes/data-ds.yaml
@@ -6,24 +6,26 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: '/prometheus'
+        prometheus.io/port: '7873'
       labels:
         role: data
-        version: 1.3.12
+        version: 1.3.15
     spec:
       containers:
       - name: quobyte-metadata
-        image: quay.io/quobyte/quobyte-server:1.3.12
+        image: quay.io/quobyte/quobyte-server:1.3.15
         securityContext:
-          privileged: true
+          capabilities:
+            add:
+              - SYS_RESOURCE
         env:
           - name: QUOBYTE_SERVICE
             value: data
           - name: QUOBYTE_REGISTRY
             value: registry
-          - name: NODENAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
           - name: MAX_MEM
             valueFrom:
               configMapKeyRef:
@@ -38,25 +40,47 @@ spec:
           - /bin/bash
           - -xec
           - |
-            hostname $NODENAME
             sed "s/.*MIN_MEM_DATA=.*/MIN_MEM_DATA=${MIN_MEM}/" -i /etc/default/quobyte
             sed "s/.*MAX_MEM_DATA=.*/MAX_MEM_DATA=${MAX_MEM}/" -i /etc/default/quobyte
-            if [ ! -f /devices/data/QUOBYTE_DEV_SETUP ]; then
-              mkdir -p /devices/data
-              cat >/devices/data/QUOBYTE_DEV_SETUP <<EOF
+
+            if [ ! "$(ls -A /devices)" ] && [ ! -f /devices/QUOBYTE_DEV_SETUP ]; then
+              mkdir -p /devices
+              cat >/devices/QUOBYTE_DEV_SETUP <<EOF
             device.serial=$(uuidgen)
             device.model=Kubernetes-hostDir
             device.type=DATA_DEVICE
             EOF
             fi
+
+            if [ ! -f /devices/UUID ]; then
+              echo uuid=$(uuidgen) >> /devices/UUID
+            fi
+
+            cat /devices/UUID >> /etc/quobyte/$QUOBYTE_SERVICE.cfg
+
             exec /bin/bash -x /opt/main.sh
         volumeMounts:
           - name: devices
-            mountPath: /devices/data
+            mountPath: /devices
         resources:
           requests:
             memory: "512Mi"
             cpu: "200m"
+       ports:
+          - name: rpc-tcp
+            containerPort: 7873
+            protocol: TCP
+        readinessProbe:
+          timeoutSeconds: 5
+          httpGet:
+            port: 7873
+            path: /
+        livenessProbe:
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          httpGet:
+            port: 7873
+            path: /
       nodeSelector:
         quobyte_data: "true"
       volumes:

--- a/kubernetes/metadata-ds.yaml
+++ b/kubernetes/metadata-ds.yaml
@@ -6,24 +6,26 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: '/prometheus'
+        prometheus.io/port: '7872'
       labels:
         role: metadata
-        version: 1.3.12
+        version: 1.3.15
     spec:
       containers:
       - name: quobyte-metadata
-        image: quay.io/quobyte/quobyte-server:1.3.12
+        image: quay.io/quobyte/quobyte-server:1.3.15
         securityContext:
-          privileged: true
+          capabilities:
+            add:
+              - SYS_RESOURCE
         env:
           - name: QUOBYTE_SERVICE
             value: metadata
           - name: QUOBYTE_REGISTRY
             value: registry
-          - name: NODENAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
           - name: MAX_MEM
             valueFrom:
               configMapKeyRef:
@@ -38,25 +40,46 @@ spec:
           - /bin/bash
           - -xec
           - |
-            hostname $NODENAME
             sed "s/.*MIN_MEM_METADATA=.*/MIN_MEM_METADATA=${MIN_MEM}/" -i /etc/default/quobyte
             sed "s/.*MAX_MEM_METADATA=.*/MAX_MEM_METADATA=${MAX_MEM}/" -i /etc/default/quobyte
-            if [ ! -f /devices/metadata/QUOBYTE_DEV_SETUP ]; then
-              mkdir -p /devices/metadata
-              cat >/devices/metadata/QUOBYTE_DEV_SETUP <<EOF
+            if [ ! "$(ls -A /devices)" ] && [ ! -f /devices/QUOBYTE_DEV_SETUP ]; then
+              mkdir -p /devices
+              cat >/devices/QUOBYTE_DEV_SETUP <<EOF
             device.serial=$(uuidgen)
             device.model=Kubernetes-hostDir
             device.type=METADATA_DEVICE
             EOF
             fi
+
+            if [ ! -f /devices/UUID ]; then
+              echo uuid=$(uuidgen) >> /devices/UUID
+            fi
+
+            cat /devices/UUID >> /etc/quobyte/$QUOBYTE_SERVICE.cfg
+
             exec /bin/bash -x /opt/main.sh
         volumeMounts:
           - name: devices
-            mountPath: /devices/metadata
+            mountPath: /devices
         resources:
           limits:
             memory: "512Mi"
             cpu: "200m"
+        ports:
+          - name: rpc-tcp
+            containerPort: 7872
+            protocol: TCP
+        readinessProbe:
+          timeoutSeconds: 5
+          httpGet:
+            port: 7872
+            path: /
+        livenessProbe:
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          httpGet:
+            port: 7872
+            path: /
       nodeSelector:
         quobyte_metadata: "true"
       volumes:

--- a/kubernetes/qmgmt-pod.yaml
+++ b/kubernetes/qmgmt-pod.yaml
@@ -3,13 +3,13 @@ kind: Pod
 metadata:
   labels:
     role: qmgmt-pod
-    version: 1.3.12
+    version: 1.3.15
   name: qmgmt-pod
   namespace: quobyte
 spec:
   containers:
     - name: qmgmt-pod
-      image: quay.io/quobyte/quobyte-server:1.3.12
+      image: quay.io/quobyte/quobyte-server:1.3.15
       command:
         - /bin/bash
         - -xec

--- a/kubernetes/quobyte-services.yaml
+++ b/kubernetes/quobyte-services.yaml
@@ -3,17 +3,21 @@ kind: Service
 metadata:
   name: registry
   namespace: quobyte
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/prometheus'
+    prometheus.io/port: '7871'
 spec:
   clusterIP: "None" # headless service => kube-dns will return pod IPs
   ports:
     - name: quobyte # available as _quobyte._tcp.registry via DNS
-      port: 7866
+      port: 7861
       protocol: TCP
     - name: rpc-udp
-      port: 7866
+      port: 7861
       protocol: UDP
     - name: http
-      port: 7876
+      port: 7871
       protocol: TCP
   selector:
     role: registry

--- a/kubernetes/registry-ds.yaml
+++ b/kubernetes/registry-ds.yaml
@@ -8,26 +8,20 @@ spec:
     metadata:
       labels:
         role: registry
-        version: 1.3.12
+        version: 1.3.15
     spec:
       containers:
         - name: quobyte-registry
-          image: quay.io/quobyte/quobyte-server:1.3.12
+          image: quay.io/quobyte/quobyte-server:1.3.15
           securityContext:
-            privileged: true
+            capabilities:
+              add:
+                - SYS_RESOURCE
           env:
             - name: QUOBYTE_SERVICE
               value: registry
-            - name: QUOBYTE_RPC_PORT
-              value: "7866"
-            - name: QUOBYTE_HTTP_PORT
-              value: "7876"
             - name: QUOBYTE_REGISTRY
               value: registry
-            - name: NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: QUOBYTE_EXTRA_SERVICE_CONFIG
               value: >
                 constants.automation.manage_registry_replicas=true
@@ -43,16 +37,13 @@ spec:
                   key: registry.min_mem
           ports:
             - name: rpc-tcp
-              containerPort: 7866
-              hostPort: 7866
+              containerPort: 7861
               protocol: TCP
             - name: rpc-udp
-              containerPort: 7866
-              hostPort: 7866
+              containerPort: 7861
               protocol: UDP
             - name: http
-              containerPort: 7876
-              hostPort: 7876
+              containerPort: 7871
               protocol: TCP
           volumeMounts:
             - name: devices
@@ -61,9 +52,10 @@ spec:
             - /bin/bash
             - -xec
             - |
-              hostname $NODENAME
               sed "s/.*MIN_MEM_REGISTRY=.*/MIN_MEM_REGISTRY=${MIN_MEM}/" -i /etc/default/quobyte
               sed "s/.*MAX_MEM_REGISTRY=.*/MAX_MEM_REGISTRY=${MAX_MEM}/" -i /etc/default/quobyte
+              # TODO if directory is not empty skip (disk is mounted)
+              # [ ! "$(ls -A /devices)" ] &&
               if [ ! -f /devices/dev1/QUOBYTE_DEV_SETUP ]; then
                 mkdir -p /devices/dev1
                 cat > /devices/dev1/QUOBYTE_DEV_SETUP <<EOF
@@ -75,6 +67,12 @@ spec:
                   echo "device.bootstrap=true" >> /devices/dev1/QUOBYTE_DEV_SETUP
                 fi
               fi
+
+              if [ ! -f /devices/dev1/UUID ]; then
+                echo uuid=$(uuidgen) >> /devices/dev1/UUID
+              fi
+
+              cat /devices/dev1/UUID >> /etc/quobyte/$QUOBYTE_SERVICE.cfg
 
               exec /bin/bash -x /opt/main.sh
           resources:
@@ -88,13 +86,13 @@ spec:
           readinessProbe:
             timeoutSeconds: 5
             httpGet:
-              port: 7876
+              port: 7871
               path: /
           livenessProbe:
             initialDelaySeconds: 30
             timeoutSeconds: 5
             httpGet:
-              port: 7876
+              port: 7871
               path: /
       nodeSelector:
         quobyte_registry: "true"

--- a/kubernetes/webconsole-deployment.yaml
+++ b/kubernetes/webconsole-deployment.yaml
@@ -8,20 +8,20 @@ spec:
     metadata:
       labels:
         role: webconsole
-        version: 1.3.12
+        version: 1.3.15
     spec:
       containers:
       - name: quobyte-webconsole
-        image: quay.io/quobyte/quobyte-server:1.3.12
+        image: quay.io/quobyte/quobyte-server:1.3.15
         env:
           - name: QUOBYTE_SERVICE
             value: "webconsole"
           - name: QUOBYTE_WEBCONSOLE_PORT
             value: "8080"
           - name: QUOBYTE_REGISTRY
-            value: registry:7866
+            value: registry
           - name: QUOBYTE_API
-            value: api:7860
+            value: api
           - name: MAX_MEM
             valueFrom:
               configMapKeyRef:
@@ -48,14 +48,14 @@ spec:
             memory: "300Mi"
             cpu: "100m"
       - name: quobyte-api
-        image: quay.io/quobyte/quobyte-server:1.3.12
+        image: quay.io/quobyte/quobyte-server:1.3.15
         env:
           - name: QUOBYTE_SERVICE
             value: api
           - name: QUOBYTE_API_PORT
             value: "7860"
           - name: QUOBYTE_REGISTRY
-            value: registry:7866
+            value: registry
           - name: QUOBYTE_LOG_LEVEL
             value: DEBUG
           - name: MAX_MEM
@@ -83,9 +83,6 @@ spec:
           limits:
             memory: "300Mi"
             cpu: "100m"
-        volumeMounts:
-            - name: devices
-              mountPath: /devices
         readinessProbe:
             timeoutSeconds: 5
             tcpSocket:
@@ -95,6 +92,3 @@ spec:
             timeoutSeconds: 10
             tcpSocket:
               port: 7860
-      volumes:
-      - name: devices
-        emptyDir:


### PR DESCRIPTION
This PR:

- Removes the privileged mode for the "server" components and add only the capability to set the `ulimits`
- Add Prometheus scrape annotations
- Update the version from 1.3.12 -> 1.3.15
- Client only mounts `/etc` of the host not the whole rootfs
- `Data` and `Metadata` service can use pre formatted disks in `/mnt/data` or `/mnt/metadata`
- If a service is restarted it can recover the `UUID` (prevents "zombie" services"